### PR TITLE
Update README.md remove git.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Automatically detects the number of CPU cores to allocate to ZRAM computation, d
 
 ## Quick Installer
 Install RPI_ZRAM from your Raspberry Pi's shell promt:
-> sudo wget -q https://git.io/vM1kx -O /tmp/rpizram && bash /tmp/rpizram
+> sudo wget -q https://raw.githubusercontent.com/novaspirit/rpi_zram/refs/heads/master/install.sh -O /tmp/rpizram && bash /tmp/rpizram
 
 The installer will complete the steps in the manual installation (below) for you.
 


### PR DESCRIPTION
The `https://git.io/vM1kx` link in the README doesn't point to this repo (novaspirit/rpi_zram)  it actually points to https://raw.githubusercontent.com/PureGrain/RPI_ZRAM/master/install.sh

My security spidey senses didn't feel comfortable with that. Not saying anything about PureGrain is attempting anything naughty. URL shortners combined with shell wget/curl commands to yet another 3rd party doesn't feel right.

Better to just remove the shortened link to a legacy git.io and put full proper URL in place.